### PR TITLE
Configure TypeScript project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Never commit generated output
+dist
+index.d.ts
+index.d.ts.map
 
 # Created by https://www.gitignore.io/api/node,code,webstorm,intellij
 # Edit at https://www.gitignore.io/?templates=node,code,webstorm,intellij

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "eslint.autoFixOnSave": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript"]
+}

--- a/package.json
+++ b/package.json
@@ -15,14 +15,20 @@
     "eslint-config-prettier": "^6.2.0",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^1.18.2",
+    "rimraf": "^3.0.0",
     "typescript": "^3.6.2"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts",
+    "index.d.ts.map"
   ],
   "scripts": {
     "format": "prettier --write src 'src/**/*'",
-    "lint": "eslint --ext .js,.ts src"
+    "lint": "eslint --ext .js,.ts src",
+    "build:types": "tsc",
+    "clean:types": "rimraf index.d.ts index.d.ts.map",
+    "build": "yarn build:types"
   },
   "prettier": {
     "singleQuote": true,
@@ -39,7 +45,24 @@
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended",
       "prettier",
+      "plugin:prettier/recommended",
       "prettier/@typescript-eslint"
-    ]
+    ],
+    "rules": {
+      "@typescript-eslint/no-parameter-properties": "error",
+      "@typescript-eslint/no-explicit-any": [
+        "error",
+        {
+          "fixToUnknown": true
+        }
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "TSEnumDeclaration[const=true]",
+          "message": "Babel cannot compile `const enum`; export simple `const` values instead."
+        }
+      ]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,68 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    // Type-check against the current version of JavaScript's standard library,
+    // most closely matching what is present in evergreen browsers.
+    "target": "es2019",
+
+    // We target native modules, since they are the future o
+    "module": "es2015",
+
+    // Do not type-check JavaScript in the project. Users can opt into this if
+    // they wish, but in general we want to guide people to the happier and
+    // easier path of just using TypeScript throughout.
+    "allowJs": false,
+
+    // We generate a "rollup" of the types into a single output file in the root
+    // directory during build, so that TS correctly looks up the types for the
+    // whole package. Here we tell `tsc` to emit to a single `outFile`...
+    "outFile": "index.js",
+    // ... but to emit only the declaration, so no `index.js` will actually be
+    // generated, only an `index.d.ts` along with its source maps. (The source
+    // will be compiled by Babel instead.)
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+
+    // Generate source maps for the declarations for nice tooling benefits. Note
+    // that unlike regular source maps, these are always emitted *beside* the
+    // declaration file and require access to the source. Since types are
+    // inherently dev-only, this works perfectly.
+    "declaration": true,
+    "declarationMap": true,
+
+    // Put the build info file for incremental compilation information in the
+    // `dist` directory so that it stays out of the way in most views of the
+    // workspace (and with leading `.` so that it's hidden in general).
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+
+    // We set `strict: true` because we always want this project and those it
+    // generates to begin with the current strictest settings TypeScript allows.
+    // Note that this *requires* that adopting any TypeScript release (major or
+    // minor) which introduces a new strictness setting constitutes a breaking
+    // change for this generator.
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Use standard Node module resolution: that is how basically *everything*
+    // expects to be able to resolve modules now. We do not otherwise need to
+    // tweak the lookup paths.
+    "moduleResolution": "node",
+
+    // Explicitly disable `esModuleInterop`: we want consumers to use ES Modules
+    // explicitly and only, rather than to use the interoperability mode that TS
+    // supplies, because it is *viral* (forcing all consumers to use the same
+    // compatibility mode) and because the future is *everything* being native.
+    "esModuleInterop": false,
+
+    // We enable decorators support so that `tsc` parses correctly and editors
+    // do the right thing automatically if the library happens to be supplying
+    // decorators; many libraries may not need this, but this makes things "just
+    // work" if they *start* to, and has no downsides in terms of generated
+    // output since we are using Babel to do the actual compilation.
+    "experimentalDecorators": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,6 +1722,13 @@ rimraf@^2.6.1:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"


### PR DESCRIPTION
- Create a good baseline TypeScript config that sets the appropriate
  strictness and project output values:
    - Set maximum strictness. This means upgrading to TS versions which introduce new strictness settings will be a breaking change, but since we will always default to generating at the highest strictness, that is what we would do anyway.
    - Target native ES modules.
    - Generates "rollups" of the project's types at the root of the project so that TypeScript will resolve them automatically and requires no special shenanigans to clean them up.
    - Document all of this so that consumers of the tool can understand why the configuration is the way it is!

- Add all build output to `.gitignore`.

- Configure ESLint for the project using `@typescript-eslint` and its integration with ESLint and Prettier.

- Commit VS Code project settings:
    - use the package TS version instead of the bundled TS version
    - run ESLint on both JS and TS files in the project (configuring it as default plus `typescript`, *not* removing the defaults)

Resolves #2.